### PR TITLE
Fix/loop in thread done callback deadlock

### DIFF
--- a/bitcoin_safe_lib/async_tools/loop_in_thread.py
+++ b/bitcoin_safe_lib/async_tools/loop_in_thread.py
@@ -154,6 +154,7 @@ class LoopInThread:
 
         bucket, lock = self._get_bucket(key)
         cancel_list: list[Future[Any]] = []
+        cleanup_callback = None
 
         with lock:
             if multiple_strategy is MultipleStrategy.REJECT_NEW_TASK:
@@ -198,7 +199,10 @@ class LoopInThread:
                             self._key_tasks.pop(key, None)
                             self._locks.pop(key, None)
 
-            fut.add_done_callback(cleanup)
+            cleanup_callback = cleanup
+
+        if cleanup_callback is not None:
+            fut.add_done_callback(cleanup_callback)
 
         # cancel old tasks outside the lock to avoid deadlock
         for old in cancel_list:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ line-length = 110
 
 [tool.poetry]
 name = "bitcoin-safe-lib"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["andreasgriffin <andreasgriffin@proton.me>"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/tests/test_loop_in_thread.py
+++ b/tests/test_loop_in_thread.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import threading
+from concurrent.futures import Future
+
+from bitcoin_safe_lib.async_tools.loop_in_thread import LoopInThread, MultipleStrategy
+
+
+def test_run_background_does_not_deadlock_when_future_is_already_done(monkeypatch) -> None:
+    loop_in_thread = LoopInThread()
+
+    def immediate_schedule(coro):
+        try:
+            coro.close()
+        except Exception:
+            pass
+        future: Future[None] = Future()
+        future.set_result(None)
+        return future
+
+    monkeypatch.setattr(loop_in_thread, "_schedule", immediate_schedule)
+
+    finished = threading.Event()
+
+    def invoke_run_background() -> None:
+        async def immediate() -> None:
+            return None
+
+        loop_in_thread.run_background(
+            immediate(),
+            key="already-done",
+            multiple_strategy=MultipleStrategy.QUEUE,
+        )
+        finished.set()
+
+    worker = threading.Thread(target=invoke_run_background)
+    worker.start()
+    worker.join(timeout=1)
+
+    try:
+        assert not worker.is_alive()
+        assert finished.is_set()
+    finally:
+        loop_in_thread.stop()


### PR DESCRIPTION
**What Changed**

In [loop_in_thread.py](/home/coder/projects/bitcoin-safe-lib/bitcoin_safe_lib/async_tools/loop_in_thread.py:145), I changed `LoopInThread.run_background()` so it no longer registers the `cleanup` done-callback while holding the per-key queue lock.

Before:
- `run_background()` acquired `lock`
- scheduled the future
- appended it to `bucket`
- called `fut.add_done_callback(cleanup)` while still inside `with lock:`

After:
- `run_background()` still acquires `lock` to update queue state
- builds the `cleanup` callback there
- releases `lock`
- only then calls `fut.add_done_callback(cleanup)`

I also added a regression test in [test_loop_in_thread.py](/home/coder/projects/bitcoin-safe-lib/tests/test_loop_in_thread.py:1) that simulates the problematic timing: the scheduled future is already completed before `add_done_callback()` is called.

**Why This Was Needed**

The deadlock comes from how Python futures behave:

- `Future.add_done_callback()` runs the callback immediately if the future is already finished.
- In the old code, that immediate callback execution happened while `run_background()` still held the same non-reentrant `threading.Lock`.
- The callback (`cleanup`) then tried to acquire that same lock again.
- Since it was a plain `Lock`, not an `RLock`, the calling thread deadlocked.

That means a caller on the GUI thread could freeze the whole app just by queueing work that completed very quickly or had already effectively completed.

**Why It Showed Up In Practice**

This was triggered by code using `MultipleStrategy.QUEUE`, especially around “ensure connected” style calls where the coroutine can return almost immediately. Once the future was already done at callback-registration time, the done-callback executed inline and re-entered the same lock.

**Why This Fix Is Correct**

The fix preserves the existing queue semantics:
- tasks are still appended to the per-key bucket under lock
- cleanup still removes the finished future from the bucket
- per-key serialization behavior is unchanged

The only behavioral change is that callback registration happens after the lock is released, which removes the reentrant deadlock window.

**Test Coverage**

The new regression test forces `_schedule()` to return an already-completed future and verifies that `run_background(..., multiple_strategy=QUEUE)` returns without hanging. That directly covers the failure mode this patch fixes.